### PR TITLE
Not deleting NAs in the data frame

### DIFF
--- a/pkg/R/run_3PG.R
+++ b/pkg/R/run_3PG.R
@@ -165,7 +165,6 @@ transf.out <- function( sim, sp_names, year_i, month_i ){
   sim$group <- rep( unique(var.default$variable_group), each = n_ob * n_sp)
   sim$variable <- rep( var.default$variable_name[order(var.default$variable_id)], each = n_ob * n_sp)
 
-  sim <- sim[!is.na(sim$value),]
 
   sim <- sim[,c('date', 'species', 'group', 'variable', 'value')]
 


### PR DESCRIPTION
I would prefer to not delete the NAs in the data frame, because when comparing different species in mixed runs this could be difficult to understand when for a species no information is present in the output, although it was initalized and useres may want to have this information. 